### PR TITLE
Rollback to use built-in spec

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,3 @@ dependencies:
   kemal:
     github: sdogruyol/kemal
     branch: master
-
-development_dependencies:
-  spec2:
-    github: waterlink/spec2.cr
-    branch: master

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,2 +1,2 @@
 require "spec"
-require "../src/todo"
+require "../src/todo/*"

--- a/spec/todo_spec.cr
+++ b/spec/todo_spec.cr
@@ -1,14 +1,13 @@
 require "./spec_helper"
-require "spec2"
 
-Spec2.describe Todo do
+describe Todo do
   describe Todo::TodoHandler do
     describe "list_todos" do
       context "When a fresh instance" do
-        let(handler) { Todo::TodoHandler.new Todo::TodoRepository.new }
-        let(todos) { handler.list_todos }
+        handler = Todo::TodoHandler.new Todo::TodoRepository.new
+        todos = handler.list_todos
         it "should list all available todo lists" do
-          expect(todos.size).to eq 1
+          todos.size.should eq 1
         end
       end
     end
@@ -19,10 +18,10 @@ Spec2.describe Todo do
         handler.add_todo_item "default_todo", "Finish work"
         default_todo = handler.list_todos[0]
         lala = Todo::TodoList.from_json default_todo.to_json
-        expect(default_todo.todo_list.size).to eq 1
-        expect(default_todo.todo_list[0].name).to eq "Finish work"
-        expect(default_todo.todo_list[0].is_done).to be_false
-        expect(default_todo.todo_list[0]._id.is_a?(String)).to be_true
+        default_todo.todo_list.size.should eq 1
+        default_todo.todo_list[0].name.should eq "Finish work"
+        default_todo.todo_list[0].is_done.should be_false
+        default_todo.todo_list[0]._id.should be_a(String)
       end
     end
 
@@ -34,7 +33,7 @@ Spec2.describe Todo do
         todo_item = default_todo.todo_list[0]
         handler.remove_todo_item default_todo._id, todo_item._id
         default_todo = handler.list_todos[0]
-        expect(default_todo.todo_list.size).to eq 0
+        default_todo.todo_list.size.should eq 0
       end
     end
 
@@ -43,7 +42,7 @@ Spec2.describe Todo do
         handler = Todo::TodoHandler.new Todo::TodoRepository.new
         handler.add_todo_item "default_todo", "Finish work"
         items = handler.list_todo_items "default_todo"
-        expect(items.size).to eq 1
+        items.size.should eq 1
       end
     end
 
@@ -52,10 +51,10 @@ Spec2.describe Todo do
         handler = Todo::TodoHandler.new Todo::TodoRepository.new
         handler.add_todo_item "default_todo", "Finish work"
         items = handler.list_todo_items "default_todo"
-        expect(items.size).to eq 1
+        items.size.should eq 1
         handler.clear_todo "default_todo"
         items = handler.list_todo_items "default_todo"
-        expect(items.size).to eq 0
+        items.size.should eq 0
       end
     end
 
@@ -67,7 +66,7 @@ Spec2.describe Todo do
         item = items[0]
         handler.mark_as_done "default_todo", item._id
         items = handler.list_todo_items "default_todo"
-        expect(items[0].is_done).to be_true
+        items[0].is_done.should be_true
       end
     end
   end


### PR DESCRIPTION
We need to use the built-in spec because we will use spec-kemal package
to test the views and the spec2 is not compatible with it.
